### PR TITLE
Added support for routes if an app has no '/' route that returns 200 OK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # pyheroku-badge
-The simplest way to include a Heroku badge in your README file.  
+
+The simplest way to include a Heroku badge in your README file.
 
 > The idea was blatantly stolen from the [heroku-badge](https://github.com/pussinboots/heroku-badge) project.
 
@@ -7,39 +8,48 @@ The simplest way to include a Heroku badge in your README file.
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## Usage
+
 Markdown:
+
 ```markdown
-![Heroku](https://pyheroku-badge.herokuapp.com/?app=<HEROKU_APP_NAME>&style=<STYLE>)
+![Heroku](https://pyheroku-badge.herokuapp.com/?app=<HEROKU_APP_NAME>&path=<ROUTE>&style=<STYLE>)
 ```
+
 reStructuredText:
+
 ```rst
-.. image:: https://pyheroku-badge.herokuapp.com/?app=<HEROKU_APP_NAME>&style=<STYLE>
+.. image:: https://pyheroku-badge.herokuapp.com/?app=<HEROKU_APP_NAME>&path=<ROUTE>&style=<STYLE>
    :target: https://<HEROKU_APP_NAME>.herokuapp.com
    :alt: Heroku
 ```
+
 Textile:
+
 ```textile
-!https://pyheroku-badge.herokuapp.com/?app=<HEROKU_APP_NAME>&style=<STYLE>!:https://<HEROKU_APP_NAME>.herokuapp.com
+!https://pyheroku-badge.herokuapp.com/?app=<HEROKU_APP_NAME>&path=<ROUTE>&style=<STYLE>!:https://<HEROKU_APP_NAME>.herokuapp.com
 ```
+
 ## Available Styles
-| `flat` (Default) | `flat-square` | `plastic` |
-| --- | --- | --- |
-| ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/deployed.svg) | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/deployed-flat-square.svg) | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/deployed-plastic.svg) |
-| ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/failed.svg) | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/failed-flat-square.svg) | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/failed-plastic.svg) |
+
+| `flat` (Default)                                                                   | `flat-square`                                                                                  | `plastic`                                                                                  |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/deployed.svg)  | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/deployed-flat-square.svg)  | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/deployed-plastic.svg)  |
+| ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/failed.svg)    | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/failed-flat-square.svg)    | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/failed-plastic.svg)    |
 | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/not-found.svg) | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/not-found-flat-square.svg) | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/not-found-plastic.svg) |
-| ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/timeout.svg) | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/timeout-flat-square.svg) | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/timeout-plastic.svg) |
+| ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/timeout.svg)   | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/timeout-flat-square.svg)   | ![Heroku](https://github.com/DenisOH/pyheroku-badge/blob/master/img/timeout-plastic.svg)   |
 
 ## FAQ
 
 - Heroku badge shows `timeout`
 
-Most likely your app is using free dynos and sleeps after 30 minutes of inactivity. If the app is sleeping, it takes roughly 15 seconds for get a response from the application. However, GitHub has a hard timeout for badges which is roughly 4 seconds.  
+Most likely your app is using free dynos and sleeps after 30 minutes of inactivity. If the app is sleeping, it takes roughly 15 seconds for get a response from the application. However, GitHub has a hard timeout for badges which is roughly 4 seconds.
 
-While [pyheroku-badge](https://github.com/DenisOH/pyheroku-badge/) can work with any Heroku application, it has to return the badge in less than 4 seconds for GitHub to render it. If your app doesn't return a response for HTTP GET request fast enough, you will see the `timeout` badge.  
+While [pyheroku-badge](https://github.com/DenisOH/pyheroku-badge/) can work with any Heroku application, it has to return the badge in less than 4 seconds for GitHub to render it. If your app doesn't return a response for HTTP GET request fast enough, you will see the `timeout` badge.
 
 The only solution would be to upgrade your app to the hobby plan.
 
 ## License
+
 ```
 WWWWWW||WWWWWW
  W W W||W W W
@@ -52,5 +62,5 @@ WWWWWW||WWWWWW
         _||_|| _||_||
        (__|__|(__|__|
 ```
-Code and documentation are available according to the MIT License (see [LICENSE](LICENSE)).
 
+Code and documentation are available according to the MIT License (see [LICENSE](LICENSE)).

--- a/app.py
+++ b/app.py
@@ -29,9 +29,15 @@ class HerokuBadge:
                 return
 
         app = req.params.get("app")
+        path = req.params.get("path")
+
+        if path is None:
+            path = "/"
+
         if not app:
             resp.status = falcon.HTTP_501
             return
+
         style = req.params.get("style")
 
         resp.cache_control = ("max-age=120",)
@@ -40,9 +46,10 @@ class HerokuBadge:
         resp.expires = datetime.now(timezone.utc) + timedelta(minutes=2)
         resp.x_dns_prefetch_control = False
 
-        url = f"https://{app}.herokuapp.com/"
+        url = f"https://{app}.herokuapp.com{path}"
         try:
             r = requests.get(url, timeout=3.6)
+            
         except requests.exceptions.Timeout:
             resp.stream, resp.content_length = get_badge(name="timeout", style=style)
         else:


### PR DESCRIPTION
I forked this repo because I didn't want to expose a blank page on a route that I didn't use in my app. 

I thought maybe some other people might find it handy too so I created a PR for it. If the path parameter is not specified it defaults to '/'.